### PR TITLE
Added an assertion to ensure only one kernel-devel package is installed

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -227,6 +227,7 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             custom_actions.AssertPleskRepositoriesNotNoneLink(),
             custom_actions.AssertMinGovernorMariadbVersion(custom_actions.FIRST_SUPPORTED_GOVERNOR_MARIADB_VERSION),
             custom_actions.AssertGovernorMysqlNotInstalled(custom_actions.FIRST_SUPPORTED_GOVERNOR_MARIADB_VERSION),
+            common_actions.AssertNoMoreThenOneKernelDevelInstalled(),
         ]
 
         if not self.upgrade_postgres_allowed:


### PR DESCRIPTION
Leapp cannot handle conversion if multiple kernel-devel packages are present, so we need to verify this on our end