### PR TITLE
Handle mailman systemd service in separate action

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -139,6 +139,7 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             ],
             "Handle plesk related services": [
                 common_actions.DisablePleskRelatedServicesDuringUpgrade(),
+                common_actions.DisableServiceDuringUpgrade("mailman.service"),
                 common_actions.HandlePleskFirewallService(),
             ],
             "Handle packages and services": [


### PR DESCRIPTION
We will now skip any interactions with the mailman service if it is not active at the start of the conversion.
By default, mailman is not configured and the service will fail to start. Therefore, attempts to start it during the revert or finishing stage will also fail.