### PR TITLE
Remove MariaDB packages on modern MariaDB upgrade before leapp.

### DIFF
--- a/cloudlinux7to8/actions/mariadb.py
+++ b/cloudlinux7to8/actions/mariadb.py
@@ -97,6 +97,8 @@ class UpdateModernMariadb(action.ActiveAction):
 
         log.debug("Set repository mapping in the leapp configuration file")
         leapp_configs.set_package_repository("mariadb", "alma-mariadb")
+
+        _remove_mariadb_packages()
         return action.ActionResult()
 
     def _post_action(self) -> action.ActionResult:


### PR DESCRIPTION
This should avoid error inside leapp upon upgrading packages, since MariaDB-server refuses to be upgraded over existing package.