### PR TITLE
Restore the progress message of the day at the finishing stage

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -176,6 +176,9 @@ class CloudLinux7to8Upgrader(DistUpgrader):
                 custom_actions.RemovePleskBaseRepository(),
                 custom_actions.DoCloudLinux7to8Convert(),
             ],
+            "Resume": [
+                common_actions.RestoreInProgressSshLoginMessage(new_os),
+            ],
             "Pause before reboot": [
             ],
             "Reboot": [


### PR DESCRIPTION
The message could be overwritten by the signal handler, for example, if we pause the process before a reboot