### PR TITLE
Re-install conflict packages before starting basic plesk services

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -162,7 +162,6 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             "Handle packages and services": [
                 custom_actions.FixOsVendorPhpFpmConfiguration(),
                 common_actions.RebundleRubyApplications(),
-                custom_actions.RemovingPleskConflictPackages(),
                 custom_actions.ReinstallPhpmyadminPleskComponents(),
                 custom_actions.ReinstallRoundcubePleskComponents(),
                 custom_actions.ReinstallConflictPackages(options.state_dir),
@@ -177,6 +176,9 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             ],
             "First plesk start": [
                 common_actions.StartPleskBasicServices(),
+            ],
+            "Remove conflicting packages": [
+                custom_actions.RemovingPleskConflictPackages(),
             ],
             "Update databases": [
                 custom_actions.UpdateMariadbDatabase(),


### PR DESCRIPTION
Some of our services depends on openssl. So we should be sure it's installed, before starting this services.