### PR TITLE
Avoid using `getlocale` results if they return `None` in PostgreSQL locale pre-check

### DIFF
--- a/cloudlinux7to8/actions/postgres.py
+++ b/cloudlinux7to8/actions/postgres.py
@@ -48,7 +48,10 @@ class AssertPostgresLocaleMatchesSystemOne(action.CheckAction):
                 return False
 
             sys_locales = set(l.split('=')[1].strip() for l in files.find_file_substrings('/etc/locale.conf', 'LANG='))
-            sys_locales.add('.'.join(map(str, locale.getlocale())))
+            env_locale = locale.getlocale()
+            if env_locale and env_locale[0]:
+                sys_locales.add('.'.join(map(str, env_locale)))
+
             if len(sys_locales) != 1:
                 log.debug(f"Got unexpected system locales set: {sys_locales!r}")
                 return False


### PR DESCRIPTION
`getlocale` can return `(None, None)` when no locale is set in the Linux environment. However, since we still have a locale defined in the configuration file, conversion should be fine as long as the configured locale matches the one used in PostgreSQL.