### PR TITLE
Exclude handling of Imunify360 extensions repositories

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -135,7 +135,6 @@ class CloudLinux7to8Upgrader(DistUpgrader):
                 custom_actions.LeappChoicesConfiguration(),
                 custom_actions.AdoptKolabRepositories(),
                 custom_actions.AdoptAtomicRepositories(),
-                custom_actions.FixupImunify(),
                 custom_actions.PatchDnfpluginErrorOutput(),
                 custom_actions.PatchLeappDebugNonAsciiPackager(),
                 common_actions.AddUpgradeSystemdService(


### PR DESCRIPTION
The CloudLinux Leapp script already manages these repositories, so there's no need for them to be handled separately by the `cloudlinux7to8`.