### PR TITLE
Pre-check if dnf could be installed before start the conversion

### DIFF
--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -262,6 +262,13 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             common_actions.AssertEnoughRamForAmavis(CLOUDLINUX8_AMAVIS_REQUIRED_RAM, self.amavis_upgrade_allowed),
             common_actions.AssertFstabOrderingIsFine(),
             common_actions.AssertFstabHasDirectRaidDevices(self.allow_raid_devices),
+            common_actions.AssertPackageAvailable(
+                "dnf",
+                name="asserting dnf package available",
+                recommendation="""The dnf package is required for Leapp to function properly.
+\tHint: You can install it using the CentOS vault extras repository with the following base URL:
+\t\t'baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/'"""
+            ),
         ]
 
         if not self.upgrade_postgres_allowed:


### PR DESCRIPTION
dnf is required for the leapp tool we use for dist-upgrade