### PR TITLE
Address DNS resolution and DNF cache failures during upgrade

### DIFF
--- a/cloudlinux7to8/actions/convert.py
+++ b/cloudlinux7to8/actions/convert.py
@@ -27,6 +27,8 @@ class DoCloudLinux7to8Convert(action.ActiveAction):
 
     def _prepare_action(self) -> action.ActionResult:
         try:
+            util.logged_check_call(["cp", "/etc/resolv.conf", "/etc/leapp/files/resolv.conf"])
+            util.logged_check_call(["/usr/bin/dnf", "clean", "all"])
             util.logged_check_call(["/usr/bin/leapp", "preupgrade"])
         except subprocess.CalledProcessError as e:
             inhibitors = leapp_configs.extract_leapp_report_inhibitors()


### PR DESCRIPTION
**Commit message:**
This commit adds two safeguards to the leapp pre-upgrade phase to prevent common failures caused by DNS and repository issues.

**Why this change is needed:**

- The upgrade process can fail with _“Couldn't resolve host name”_ due to DNS resolution problems inside the temporary leapp container.
- Repository metadata may be stale or corrupted, leading to DNF errors when fetching packages.

**What this change does:**

- **DNS fix:** Copies `/etc/resolv.conf` into `/etc/leapp/files/` so the leapp container has valid nameserver settings.
- **DNF cache fix:** Runs `dnf clean all` to clear stale repository metadata and caches, preventing curl and download errors.