### PR TITLE
Remove legacy psa-fileserver package prior to system conversion

### DIFF
--- a/cloudlinux7to8/actions/packages.py
+++ b/cloudlinux7to8/actions/packages.py
@@ -39,6 +39,31 @@ class RemovingPleskConflictPackages(action.ActiveAction):
         return 10
 
 
+class RemovePleskOutdatedPackages(action.ActiveAction):
+    outdated_pkgs: typing.List[str]
+
+    def __init__(self) -> None:
+        self.name = "remove plesk outdated packages"
+        self.outdated_pkgs = [
+            "psa-fileserver",
+        ]
+
+    def _prepare_action(self) -> action.ActionResult:
+        packages.remove_packages(rpm.filter_installed_packages(self.outdated_pkgs))
+        return action.ActionResult()
+
+    def _post_action(self) -> action.ActionResult:
+        return action.ActionResult()
+
+    def _revert_action(self) -> action.ActionResult:
+        # This packages are outdated so they not provided by modern Plesk repositories
+        # So we can't reinstall them on revert, and seems like there is no need to do that anyway
+        return action.ActionResult()
+
+    def estimate_prepare_time(self) -> int:
+        return 2
+
+
 class ReinstallPhpmyadminPleskComponents(action.ActiveAction):
     def __init__(self) -> None:
         self.name = "re-installing plesk components"

--- a/cloudlinux7to8/upgrader.py
+++ b/cloudlinux7to8/upgrader.py
@@ -180,6 +180,7 @@ class CloudLinux7to8Upgrader(DistUpgrader):
             ],
             "Remove conflicting packages": [
                 custom_actions.RemovingPleskConflictPackages(),
+                custom_actions.RemovePleskOutdatedPackages(),
             ],
             "Update databases": [
                 custom_actions.UpdateMariadbDatabase(),


### PR DESCRIPTION
The psa-fileserver package originates from older Plesk versions and is no longer available in modern repositories.

During conversion, Leapp attempts to install new packages inside a temporary container, but fails due to the presence of this outdated package—leaving the instance in an unconverted state.

To prevent this, we safely remove psa-fileserver as part of the conversion process.